### PR TITLE
Feature/windows support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted to native line endings on checkout
+*.sh text eol=lf
+*.go text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.toml text eol=lf
+
+# Declare files that should always have CRLF line endings on checkout
+*.bat text eol=crlf
+
+# Denote all files that are truly binary and should not be modified
+*.png binary
+*.jpg binary
+*.ico binary
+*.gz binary
+*.zip binary

--- a/README.md
+++ b/README.md
@@ -15,13 +15,31 @@ cp .env.example .env
 
 ### Start environment
 
-bash pta-cli.sh compose up -b -e prod  
-bash pta-cli.sh compose up -b -e dev
+   ```bash
+   bash pta-cli.sh compose up -b -e prod
+   bash pta-cli.sh compose up -b -e dev
+   ```
 
 ### Navigate to the platform
 
 Open https://pwnthemall.local/ & accept the certificate
 
+### Windows Support
+#### Required :
+   - Windows Subsystem for Linux
+   - Git Bash
+
+Use the provided `pta-cli.cmd` wrapper which will automatically detect and use WSL or Git Bash:
+   ```shell
+   pta-cli.cmd compose up -b -e prod
+   pta-cli.cmd compose up -b -e dev
+   ```
+
+Alternatively, you can run commands directly through WSL or Git Bash:
+   ```bash
+   bash pta-cli.sh compose up -b -e prod
+   bash pta-cli.sh compose up -b -e dev
+   ```
 
 ## Troubleshoot
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ cp .env.example .env
 Open https://pwnthemall.local/ & accept the certificate
 
 ### Windows Support
-Can run the same way as linux if executed directly in the WSL terminal
-#### Required :
-   - Windows Subsystem for Linux
-   - Git Bash
+Can run the same way as Linux if executed directly in the WSL terminal.
+#### Requirements:
+   - Windows Subsystem for Linux (WSL)
+   - Alternatively, Git Bash (if WSL is not available)
 
-Use the provided `pta-cli.cmd` wrapper which will automatically detect and use WSL or Git 
+Use the provided `pta-cli.cmd` wrapper, which will automatically detect and use WSL if available, or fall back to Git Bash. 
    ```shell
    pta-cli.cmd compose up -b -e prod
    pta-cli.cmd compose up -b -e dev

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Use the provided `pta-cli.cmd` wrapper which will automatically detect and use W
    pta-cli.cmd compose up -b -e prod
    pta-cli.cmd compose up -b -e dev
    ```
+nb: The default WSL must be compatible
 
 Alternatively, you can run commands directly through WSL or Git Bash:
    ```bash

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ cp .env.example .env
 Open https://pwnthemall.local/ & accept the certificate
 
 ### Windows Support
+Can run the same way as linux if executed directly in the WSL terminal
 #### Required :
    - Windows Subsystem for Linux
    - Git Bash
 
-Use the provided `pta-cli.cmd` wrapper which will automatically detect and use WSL or Git (Can run the same way as linux if executed directly in the wsl terminal)
+Use the provided `pta-cli.cmd` wrapper which will automatically detect and use WSL or Git 
    ```shell
    pta-cli.cmd compose up -b -e prod
    pta-cli.cmd compose up -b -e dev

--- a/README.md
+++ b/README.md
@@ -29,17 +29,10 @@ Open https://pwnthemall.local/ & accept the certificate
    - Windows Subsystem for Linux
    - Git Bash
 
-Use the provided `pta-cli.cmd` wrapper which will automatically detect and use WSL or Git Bash:
+Use the provided `pta-cli.cmd` wrapper which will automatically detect and use WSL or Git (Can run the same way as linux if executed directly in the wsl terminal)
    ```shell
    pta-cli.cmd compose up -b -e prod
    pta-cli.cmd compose up -b -e dev
-   ```
-nb: The default WSL must be compatible
-
-Alternatively, you can run commands directly through WSL or Git Bash:
-   ```bash
-   bash pta-cli.sh compose up -b -e prod
-   bash pta-cli.sh compose up -b -e dev
    ```
 
 ## Troubleshoot

--- a/backend/main.go
+++ b/backend/main.go
@@ -27,7 +27,7 @@ func main() {
 	config.ConnectDB()
 	config.ConnectMinio()
 	config.InitCasbin()
-	// config.ConnectDocker()
+	config.ConnectDocker()
 	router := gin.Default()
 
 	sessionSecret := os.Getenv("SESSION_SECRET")

--- a/backend/main.go
+++ b/backend/main.go
@@ -27,7 +27,7 @@ func main() {
 	config.ConnectDB()
 	config.ConnectMinio()
 	config.InitCasbin()
-	config.ConnectDocker()
+	// config.ConnectDocker()
 	router := gin.Default()
 
 	sessionSecret := os.Getenv("SESSION_SECRET")

--- a/pta-cli.cmd
+++ b/pta-cli.cmd
@@ -1,0 +1,27 @@
+@echo off
+REM Windows wrapper for pta-cli.sh
+REM Requires Git Bash or WSL to be installed
+
+setlocal enabledelayedexpansion
+
+REM Check if we're running in WSL
+where bash >nul 2>&1
+if %ERRORLEVEL% equ 0 (
+    bash -c "./pta-cli.sh %*"
+    exit /b %ERRORLEVEL%
+)
+
+REM Check if Git Bash is installed
+where git >nul 2>&1
+if %ERRORLEVEL% equ 0 (
+    for /f "delims=" %%i in ('where git') do (
+        set "git_path=%%~dpi"
+    )
+    if defined git_path (
+        "%git_path%bash.exe" -c "./pta-cli.sh %*"
+        exit /b %ERRORLEVEL%
+    )
+)
+
+echo Error: Could not find bash interpreter (WSL or Git Bash required)
+exit /b 1

--- a/pta-cli.cmd
+++ b/pta-cli.cmd
@@ -1,27 +1,83 @@
 @echo off
-REM Windows wrapper for pta-cli.sh
-REM Requires Git Bash or WSL to be installed
-
 setlocal enabledelayedexpansion
 
-REM Check if we're running in WSL
-where bash >nul 2>&1
-if %ERRORLEVEL% equ 0 (
-    bash -c "./pta-cli.sh %*"
-    exit /b %ERRORLEVEL%
+echo Searching for valid WSL or Git Bash interpreter...
+
+rem Store arguments
+set "args=%*"
+
+rem Try to find Ubuntu specifically first
+if not "%WSL_WRAPPER_ACTIVE%"=="1" (
+    wsl -d Ubuntu --version >nul 2>&1
+    if %ERRORLEVEL% equ 0 (
+        echo Using Ubuntu WSL
+        set WSL_WRAPPER_ACTIVE=1
+        wsl -d Ubuntu bash -c "export WSL_WRAPPER_ACTIVE=1 && ./pta-cli.sh %args%"
+        exit /b %ERRORLEVEL%
+    )
+) else (
+    echo WSL Wrapper already active, avoiding recursion
+    exit /b 1
 )
 
-REM Check if Git Bash is installed
-where git >nul 2>&1
-if %ERRORLEVEL% equ 0 (
-    for /f "delims=" %%i in ('where git') do (
-        set "git_path=%%~dpi"
+rem If Ubuntu not found, try other distributions
+echo Ubuntu not found, searching for other distributions...
+set "found_distro="
+
+rem Parse WSL distributions
+for /f "usebackq skip=1" %%i in (`wsl -l -v 2^>nul`) do (
+    set "line=%%i"
+    
+    rem Extract distribution name (handle both with and without asterisk)
+    if "!line:~0,1!"=="*" (
+        rem Line starts with asterisk, get name from position 2
+        for /f "tokens=1" %%j in ("!line:~2!") do set "distro=%%j"
+    ) else (
+        rem No asterisk, get first token
+        for /f "tokens=1" %%j in ("!line!") do set "distro=%%j"
     )
-    if defined git_path (
-        "%git_path%bash.exe" -c "./pta-cli.sh %*"
+    
+    echo Debug: Checking distribution: "!distro!"
+    
+    rem Skip Docker and empty
+    if /i not "!distro!"=="docker-desktop" if /i not "!distro!"=="docker-desktop-data" if not "!distro!"=="" (
+        set "found_distro=!distro!"
+        goto :use_wsl
+    )
+)
+
+echo ❌ No compatible WSL distribution found.
+goto :try_gitbash
+
+:use_wsl
+echo Using WSL distribution: !found_distro!
+rem Set environment variable to prevent recursion
+set WSL_WRAPPER_ACTIVE=1
+wsl -d "!found_distro!" bash -c "export WSL_WRAPPER_ACTIVE=1 && ./pta-cli.sh %args%"
+exit /b %ERRORLEVEL%
+
+:try_gitbash
+echo Trying with Git Bash...
+set "gitbash_path=C:\Program Files\Git\bin\bash.exe"
+if exist "%gitbash_path%" (
+    echo Using native Git Bash
+    set WSL_WRAPPER_ACTIVE=1
+    "%gitbash_path%" -c "export WSL_WRAPPER_ACTIVE=1 && ./pta-cli.sh %args%"
+    exit /b %ERRORLEVEL%
+) else (
+    rem Try alternative Git Bash locations
+    set "gitbash_path=C:\Program Files (x86)\Git\bin\bash.exe"
+    if exist "!gitbash_path!" (
+        echo Using native Git Bash (x86)
+        set WSL_WRAPPER_ACTIVE=1
+        "!gitbash_path!" -c "export WSL_WRAPPER_ACTIVE=1 && ./pta-cli.sh %args%"
         exit /b %ERRORLEVEL%
     )
 )
 
-echo Error: Could not find bash interpreter (WSL or Git Bash required)
+echo ❌ No valid bash interpreter found.
+echo.
+echo Possible solutions:
+echo - Install WSL: wsl --install
+echo - Install Git for Windows with Git Bash
 exit /b 1

--- a/pta-cli.cmd
+++ b/pta-cli.cmd
@@ -37,7 +37,7 @@ for /f "usebackq skip=1" %%i in (`wsl -l -v 2^>nul`) do (
         for /f "tokens=1" %%j in ("!line!") do set "distro=%%j"
     )
     
-    echo Debug: Checking distribution: "!distro!"
+    if "%DEBUG%"=="1" echo Debug: Checking distribution: "!distro!"
     
     rem Skip Docker and empty
     if /i not "!distro!"=="docker-desktop" if /i not "!distro!"=="docker-desktop-data" if not "!distro!"=="" (


### PR DESCRIPTION
Readme can be ignored (uncompleted/not clear)
The wrapper pta-cli.cmd is optionnal and only needed if user is too lazy to execute the sh directly in WSL terminal
Real change in the gitattributes

Tested on 2 different windows with 2 different WSL work on both even if the compatible WSL is not defaulted
Git bash not tested